### PR TITLE
Download millage.csv from the portal during Travis CI builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ ALL := $(ENV)/.all
 
 # Main Targets ###############################################################
 
+CKAN_ID := b4efaad7-2e38-4b9e-8bf6-a50113a589d1
+CKAN_URL := http://data.grcity.us/dataset/grand-rapids-parks-millage/resource/$(CKAN_ID)
+
 .PHONY: all
 all: depends doc $(ALL)
 $(ALL): $(SOURCES)
@@ -92,6 +95,12 @@ parks.geojson: depends parks.osm_json
 osm_json: parks.osm_json
 parks.osm_json: depends data/millage.csv
 	$(PYTHON) $(PACKAGE)/main.py data/millage.csv
+
+ifdef TRAVIS
+.PHONY: data/millage.csv
+endif
+data/millage.csv:
+	curl $(CKAN_URL) | grep -m 1 -o 'http:.*\.csv' | xargs curl > $@
 
 # Development Installation ###################################################
 

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,7 @@
+The files in this directory are now automatically downloaded from [Grand Rapids Open Data](http://data.grcity.us/dataset/grand-rapids-parks-millage) during builds on Travis CI.
+
+To trigger this process locally:
+
+```
+make run TRAVIS=true
+```


### PR DESCRIPTION
@Crevax This is how I might considering downloading the CSV from the data portal during builds.