### PR TITLE
Explicitly include "Covell Dog Park"

### DIFF
--- a/parks/finder.py
+++ b/parks/finder.py
@@ -33,6 +33,7 @@ BBOXES = (
 PARK_NAMES = (
     "Indian Trails Golf Course",
     "Riverwalk Trails",
+    "Covell Dog Park",
 )
 
 log = common.logger(__name__)


### PR DESCRIPTION
This is not tagged as a `park` but instead a `dog park` so we have to explicitly include it.

Closes #46 